### PR TITLE
Add AI-driven Vikunja node

### DIFF
--- a/credentials/OpenAIApi.credentials.ts
+++ b/credentials/OpenAIApi.credentials.ts
@@ -1,0 +1,34 @@
+import {
+	IAuthenticateGeneric,
+	ICredentialTestRequest,
+	ICredentialType,
+	INodeProperties,
+} from 'n8n-workflow';
+
+export class OpenAIApi implements ICredentialType {
+	name = 'openAiApi';
+	displayName = 'OpenAI API';
+	properties: INodeProperties[] = [
+		{
+			displayName: 'API Key',
+			name: 'apiKey',
+			type: 'string',
+			typeOptions: { password: true },
+			default: '',
+		},
+	];
+	authenticate: IAuthenticateGeneric = {
+		type: 'generic',
+		properties: {
+			headers: {
+				Authorization: '=Bearer {{$credentials.apiKey}}',
+			},
+		},
+	};
+	test: ICredentialTestRequest = {
+		request: {
+			method: 'GET',
+			url: 'https://api.openai.com/v1/models',
+		},
+	};
+}

--- a/nodes/Vikunja/VikunjaAI.node.json
+++ b/nodes/Vikunja/VikunjaAI.node.json
@@ -1,0 +1,10 @@
+{
+	"node": "n8n-nodes-base.vikunjaAi",
+	"nodeVersion": "1.0",
+	"codexVersion": "1.0",
+	"categories": ["AI", "Productivity"],
+	"resources": {
+		"credentialDocumentation": [{ "url": "https://vikunja.io/docs/n8n" }],
+		"primaryDocumentation": [{ "url": "https://vikunja.io/docs/n8n" }]
+	}
+}

--- a/nodes/Vikunja/VikunjaAI.node.ts
+++ b/nodes/Vikunja/VikunjaAI.node.ts
@@ -1,0 +1,110 @@
+import {
+	IHttpRequestMethods,
+	IExecuteFunctions,
+	INodeType,
+	INodeTypeDescription,
+} from 'n8n-workflow';
+import { apiRequest } from './helper';
+
+export class VikunjaAI implements INodeType {
+	description: INodeTypeDescription = {
+		displayName: 'Vikunja AI',
+		name: 'vikunjaAi',
+		icon: 'file:vikunja.svg',
+		group: ['transform'],
+		version: 1,
+		description: 'Control Vikunja via natural language using OpenAI',
+		defaults: {
+			name: 'Vikunja AI',
+		},
+		inputs: ['main'],
+		outputs: ['main'],
+		credentials: [
+			{
+				name: 'openAiApi',
+				required: true,
+			},
+			{
+				name: 'vikunjaApi',
+				required: true,
+			},
+		],
+		properties: [
+			{
+				displayName: 'Instruction',
+				name: 'instruction',
+				type: 'string',
+				default: '',
+				description: 'Instruction in natural language describing a Vikunja operation',
+			},
+		],
+	};
+
+	async execute(this: IExecuteFunctions) {
+		const instruction = this.getNodeParameter('instruction', 0) as string;
+
+		const requestBody = {
+			model: 'gpt-3.5-turbo-0613',
+			messages: [
+				{
+					role: 'system',
+					content:
+						'Translate the user instruction to a Vikunja API request.' +
+						' Respond using the function calling format.',
+				},
+				{ role: 'user', content: instruction },
+			],
+			functions: [
+				{
+					name: 'vikunja_request',
+					description: 'Vikunja API request to perform',
+					parameters: {
+						type: 'object',
+						properties: {
+							method: {
+								type: 'string',
+								enum: ['GET', 'POST', 'PUT', 'DELETE'],
+							},
+							endpoint: { type: 'string' },
+							body: { type: 'object' },
+							query: { type: 'object' },
+						},
+						required: ['method', 'endpoint'],
+					},
+				},
+			],
+			function_call: { name: 'vikunja_request' },
+		};
+
+		const aiResponse = await this.helpers.httpRequestWithAuthentication.call(this, 'openAiApi', {
+			method: 'POST',
+			url: 'https://api.openai.com/v1/chat/completions',
+			json: requestBody,
+		});
+
+		const args = aiResponse?.choices?.[0]?.message?.function_call?.arguments;
+		if (!args) {
+			throw new Error('No function arguments returned from AI');
+		}
+
+		let requestParams: {
+			method: IHttpRequestMethods;
+			endpoint: string;
+			body?: object;
+			query?: object;
+		};
+		try {
+			requestParams = JSON.parse(args);
+		} catch {
+			throw new Error('Failed to parse AI response');
+		}
+
+		const { method, endpoint, body, query } = requestParams;
+
+		const responseData = await apiRequest.call(this, method, endpoint, body, query);
+
+		return this.helpers.returnJsonArray(
+			Array.isArray(responseData) ? responseData : [responseData],
+		);
+	}
+}

--- a/package.json
+++ b/package.json
@@ -30,11 +30,13 @@
   "n8n": {
     "n8nNodesApiVersion": 1,
     "credentials": [
-      "dist/credentials/VikunjaApi.credentials.js"
+      "dist/credentials/VikunjaApi.credentials.js",
+      "dist/credentials/OpenAIApi.credentials.js"
     ],
     "nodes": [
       "dist/nodes/Vikunja/Vikunja.node.js",
-      "dist/nodes/Vikunja/VikunjaTrigger.node.js"
+      "dist/nodes/Vikunja/VikunjaTrigger.node.js",
+      "dist/nodes/Vikunja/VikunjaAI.node.js"
     ]
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- add OpenAI credential type
- enable controlling Vikunja via natural language with new node
- reference AI credential and node in package.json

## Testing
- `npm run format`
- `npm run build` *(fails: `gulp` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_6873baff6bc0832eace69703f48164a2